### PR TITLE
Removed useless warning

### DIFF
--- a/tools/roomservice.py
+++ b/tools/roomservice.py
@@ -235,9 +235,6 @@ if depsonly:
     repo_path = get_from_manifest(device)
     if repo_path:
         fetch_dependencies(repo_path)
-    else:
-        print("Trying dependencies-only mode on a non-existing device tree?")
-
     sys.exit()
 
 else:


### PR DESCRIPTION
No need to check if allready existing device tree really exists.
We dont want the build system to download the device trees on demand.
So why should it be allowed to send an error about this?
